### PR TITLE
use the bundled version of notes instead of manually installing it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
 
       # install and configure tutor and kubectl
       - name: Configure Github workflow environment
-        uses: openedx-actions/tutor-k8s-init@v1.0.0
+        uses: openedx-actions/tutor-k8s-init@v1.0.4
         with:
           namespace: openedx-prod
 
@@ -50,7 +50,7 @@ jobs:
 
       # This action.
       - name: Enable tutor plugin - Notes
-        uses: openedx-actions/tutor-enable-plugin-notes@v1.0.0
+        uses: openedx-actions/tutor-enable-plugin-notes@v1.0.1
         with:
           namespace: openedx-prod
 

--- a/action.yml
+++ b/action.yml
@@ -33,10 +33,15 @@ runs:
         eks-namespace: ${{ inputs.namespace }}
         eks-secret-name: mysql-notes
 
-    - name: install Notes plugin
-      id: install-notes
-      shell: bash
-      run: pip install tutor-notes
+    # mcdaniel nov-2022
+    # see: https://github.com/overhangio/tutor-notes
+    # The plugin is currently bundled with the binary releases of Tutor.
+    # It's only necessary to pip install if you have installed Tutor from source.
+    #------------------------------------------------------
+    #- name: install Notes plugin
+    #  id: install-notes
+    #  shell: bash
+    #  run: pip install tutor-notes
 
     - name: Enable the Notes plugin
       id: config-save


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation
- [ * ] Refactor
- [ ] Chore

### Describe Changes
Notes plugin is now bundled with the binary release of Tutor. We now only need to pull the mysql credentials and enable the preexisting plugin.