### PR TITLE
revert last version release. we really *do* need to pip install tutor…

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
 
       # This action.
       - name: Enable tutor plugin - Notes
-        uses: openedx-actions/tutor-enable-plugin-notes@v1.0.1
+        uses: openedx-actions/tutor-enable-plugin-notes@v1.0.2
         with:
           namespace: openedx-prod
 

--- a/action.yml
+++ b/action.yml
@@ -37,11 +37,13 @@ runs:
     # see: https://github.com/overhangio/tutor-notes
     # The plugin is currently bundled with the binary releases of Tutor.
     # It's only necessary to pip install if you have installed Tutor from source.
+    #
+    # However, since we pip install tutor we apparently *ARE* installing tutor from source.
     #------------------------------------------------------
-    #- name: install Notes plugin
-    #  id: install-notes
-    #  shell: bash
-    #  run: pip install tutor-notes
+    - name: install Notes plugin
+      id: install-notes
+      shell: bash
+      run: pip install tutor-notes
 
     - name: Enable the Notes plugin
       id: config-save


### PR DESCRIPTION
…-notes

### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [ * ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- turns out that we really *do* need to pip install tutor-notes, since we pip install tutor itself.
